### PR TITLE
Fix typo in Cloudflare KV store reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ Click-to-shoot enemies from the centre. Enemies come in from the edge of the map
 - Blood effects on death/damage
 - Health boosts if arrow missed but targeted
 - Piercing arrows (an upgrade)?
-- Web leaderboard/api with coin records (Cloudflare K/V store?)
+- Web leaderboard/api with coin records (Cloudflare KV store?)


### PR DESCRIPTION
As per cloudflares naming conventions, a Key-Store is spelled as KV. This pull request fixes the spelling mistake found in the readme.md file. See https://developers.cloudflare.com/kv/ for more information.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iBaguette/codesmith/hacknotts-25/pr/11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784397973&installation_id=127894808&pr_number=11&repository=iBaguette%2Fhacknotts-25&return_to=https%3A%2F%2Fgithub.com%2FiBaguette%2Fhacknotts-25%2Fpull%2F11&signature=582b02ca5c1c539bda436025c53f48b38e9f83a33f2594bdd25cc607cc39c469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->